### PR TITLE
Cesium Improvements

### DIFF
--- a/client/src/components/CesiumViewer.vue
+++ b/client/src/components/CesiumViewer.vue
@@ -5,13 +5,23 @@
 #############################################################################*/
 
 <template>
-  <div>
-    <vc-viewer baseLayerPicker @ready="ready"
-      ><vc-layer-imagery>
+  <div :style="{ height: '87%' }">
+    <v-switch
+      label="Show Bounding Volumes"
+      v-model="debugShowBoundingVolume"
+    ></v-switch>
+    <vc-viewer baseLayerPicker fullscreenButton @ready="ready">
+      <vc-layer-imagery>
         <vc-provider-imagery-ion :assetId="3" />
       </vc-layer-imagery>
-      <vc-provider-terrain-cesium />
-      <vc-primitive-tileset :url="url" @readyPromise="readyPromise" />
+      <vc-layer-imagery>
+        <vc-provider-terrain-cesium />
+      </vc-layer-imagery>
+      <vc-primitive-tileset
+        :url="url"
+        @readyPromise="readyPromise"
+        :debugShowContentBoundingVolume="debugShowBoundingVolume"
+      />
     </vc-viewer>
   </div>
 </template>
@@ -26,6 +36,7 @@ export default {
   data() {
     return {
       cesiumInstance: null,
+      debugShowBoundingVolume: false,
     };
   },
   asyncComputed: {

--- a/client/src/components/CesiumViewer.vue
+++ b/client/src/components/CesiumViewer.vue
@@ -12,10 +12,7 @@
     ></v-switch>
     <vc-viewer baseLayerPicker fullscreenButton @ready="ready">
       <vc-layer-imagery>
-        <vc-provider-imagery-ion :assetId="3" />
-      </vc-layer-imagery>
-      <vc-layer-imagery>
-        <vc-provider-terrain-cesium />
+        <vc-provider-imagery-ion :assetId="2" />
       </vc-layer-imagery>
       <vc-primitive-tileset
         :url="url"

--- a/client/src/components/CesiumViewer.vue
+++ b/client/src/components/CesiumViewer.vue
@@ -6,7 +6,11 @@
 
 <template>
   <div>
-    <vc-viewer @ready="ready">
+    <vc-viewer baseLayerPicker @ready="ready"
+      ><vc-layer-imagery>
+        <vc-provider-imagery-ion :assetId="3" />
+      </vc-layer-imagery>
+      <vc-provider-terrain-cesium />
       <vc-primitive-tileset :url="url" @readyPromise="readyPromise" />
     </vc-viewer>
   </div>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -24,7 +24,10 @@ girder.girder.$refresh().then(() => {
   Vue.use(ResonantGeo, {
     girder: girder.girder,
   });
-  Vue.use(VueCesium);
+  Vue.use(VueCesium, {
+    // default Cesium Ion API key
+    accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI1MDA2NzVhYi05NjljLTQ2ZWQtYWJkZC1jYTg4NzA4YjEzNGMiLCJpZCI6MjU5LCJpYXQiOjE2MjUxNTA1ODh9.hDxkoBgpk13oYPDuKYhkt6XSyii_kUKufDE_GLE38is'
+  });
   Vue.use(VuePortals);
   new Vue({
     router,


### PR DESCRIPTION
- Adds a toggle to enable "bounding volumes" in Cesium viewer
- Add button to change imagery/terrain in Cesium viewer

A Cesium Ion API key is required to enable the imagery. For now this uses the default key that Cesium provides, but we probably want to get our own key at some point. 